### PR TITLE
perf(backend): add safe query limits and indexes

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -77,7 +77,14 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 // ── Serve uploaded files statically ───────────────────────────────────────────
-app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
+app.use(
+  '/uploads',
+  express.static(path.join(__dirname, 'uploads'), {
+    maxAge: isProduction ? '7d' : 0,
+    etag: true,
+    lastModified: true,
+  })
+);
 
 // ── Serve frontend locally from the backend in development ───────────────────
 const frontendDir = path.resolve(__dirname, '..', 'frontend');

--- a/backend/controllers/postController.js
+++ b/backend/controllers/postController.js
@@ -69,14 +69,18 @@ async function createPost(req, res) {
 
 async function getPosts(req, res) {
     try {
-        const { farmerId, authorId, limit = 20 } = req.query;
+        const { farmerId, authorId, page = 1, limit = 20 } = req.query;
         const query = {};
+        const pageNumber = Math.max(Number(page) || 1, 1);
+        const pageSize = Math.min(Math.max(Number(limit) || 20, 1), 100);
+        const skip = (pageNumber - 1) * pageSize;
         const ownerId = farmerId || authorId;
         if (ownerId) query['author.userId'] = ownerId;
 
         const posts = await Post.find(query)
             .sort({ createdAt: -1 })
-            .limit(Math.min(Number(limit) || 20, 100));
+            .skip(skip)
+            .limit(pageSize);
 
         return res.json({
             success: true,

--- a/backend/controllers/productController.js
+++ b/backend/controllers/productController.js
@@ -101,8 +101,11 @@ async function createProduct(req, res) {
 
 async function getProducts(req, res) {
     try {
-        const { category, search, farmerId, minPrice, maxPrice, limit = 20 } = req.query;
+        const { category, search, farmerId, minPrice, maxPrice, page = 1, limit = 20 } = req.query;
         const query = {};
+        const pageNumber = Math.max(Number(page) || 1, 1);
+        const pageSize = Math.min(Math.max(Number(limit) || 20, 1), 100);
+        const skip = (pageNumber - 1) * pageSize;
 
         if (category) query.category = String(category).toLowerCase();
         if (farmerId) query['seller.userId'] = farmerId;
@@ -115,7 +118,8 @@ async function getProducts(req, res) {
 
         const products = await Product.find(query)
             .sort({ createdAt: -1 })
-            .limit(Math.min(Number(limit) || 20, 100));
+            .skip(skip)
+            .limit(pageSize);
 
         return res.json({
             success: true,

--- a/backend/models/Message.js
+++ b/backend/models/Message.js
@@ -35,5 +35,8 @@ const messageSchema = new mongoose.Schema(
 );
 
 messageSchema.index({ sender: 1, receiver: 1, createdAt: -1 });
+messageSchema.index({ sender: 1, createdAt: -1 });
+messageSchema.index({ receiver: 1, createdAt: -1 });
+messageSchema.index({ receiver: 1, isRead: 1, createdAt: -1 });
 
 module.exports = mongoose.model('Message', messageSchema);

--- a/backend/models/Post.js
+++ b/backend/models/Post.js
@@ -41,4 +41,8 @@ const postSchema = new mongoose.Schema({
     },
 }, { timestamps: true });
 
+postSchema.index({ createdAt: -1 });
+postSchema.index({ 'author.userId': 1, createdAt: -1 });
+postSchema.index({ linkedProductId: 1, createdAt: -1 });
+
 module.exports = mongoose.model('Post', postSchema);

--- a/backend/models/Product.js
+++ b/backend/models/Product.js
@@ -99,5 +99,9 @@ const productSchema = new mongoose.Schema({
 }, { timestamps: true });
 
 productSchema.index({ name: 'text', description: 'text', category: 'text' });
+productSchema.index({ 'seller.userId': 1, createdAt: -1 });
+productSchema.index({ category: 1, createdAt: -1 });
+productSchema.index({ sellingPrice: 1, createdAt: -1 });
+productSchema.index({ stock: 1, createdAt: -1 });
 
 module.exports = mongoose.model('Product', productSchema);

--- a/backend/models/Profile.js
+++ b/backend/models/Profile.js
@@ -55,4 +55,8 @@ const profileSchema = new mongoose.Schema({
     },
 }, { timestamps: true });
 
+profileSchema.index({ userId: 1, role: 1 });
+profileSchema.index({ role: 1, location: 1 });
+profileSchema.index({ role: 1, farmLocation: 1 });
+
 module.exports = mongoose.model('Profile', profileSchema);

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -96,4 +96,8 @@ userSchema.methods.toJSON = function () {
   return obj;
 };
 
+userSchema.index({ role: 1, isActive: 1, createdAt: -1 });
+userSchema.index({ role: 1, address: 1, createdAt: -1 });
+userSchema.index({ friends: 1 });
+
 module.exports = mongoose.model('User', userSchema);

--- a/backend/routes/users.routes.js
+++ b/backend/routes/users.routes.js
@@ -20,7 +20,15 @@ const { successResponse } = require('../utils/apiResponse');
 // GET /api/users/farmers  — list all farmer accounts
 router.get('/farmers', async (req, res, next) => {
   try {
-    const farmers = await User.find({ role: 'farmer', isActive: true }, '-password').sort({ createdAt: -1 });
+    const page = Math.max(Number(req.query.page) || 1, 1);
+    const limit = Math.min(Math.max(Number(req.query.limit) || 50, 1), 100);
+    const skip = (page - 1) * limit;
+
+    const farmers = await User.find({ role: 'farmer', isActive: true }, '-password')
+      .sort({ createdAt: -1 })
+      .skip(skip)
+      .limit(limit);
+
     return successResponse(res, 'Farmers list', farmers);
   } catch (err) { next(err); }
 });
@@ -28,7 +36,15 @@ router.get('/farmers', async (req, res, next) => {
 // GET /api/users/customers  — list all buyer accounts (legacy name for compatibility)
 router.get('/customers', async (req, res, next) => {
   try {
-    const customers = await User.find({ role: 'customer', isActive: true }, '-password').sort({ createdAt: -1 });
+    const page = Math.max(Number(req.query.page) || 1, 1);
+    const limit = Math.min(Math.max(Number(req.query.limit) || 50, 1), 100);
+    const skip = (page - 1) * limit;
+
+    const customers = await User.find({ role: 'customer', isActive: true }, '-password')
+      .sort({ createdAt: -1 })
+      .skip(skip)
+      .limit(limit);
+
     return successResponse(res, 'Customers list', customers);
   } catch (err) { next(err); }
 });


### PR DESCRIPTION
This PR improves backend performance safely.

Changes:
- Added MongoDB indexes for users, products, posts, profiles, and messages.
- Added pagination support to public farmers/customers lists.
- Added pagination support to products and posts endpoints.
- Kept existing response shapes unchanged to avoid frontend breakage.
- Added production cache headers for uploaded static files.
- Verified changed backend files with node --check.

Note:
Existing backend tests currently need separate repair because the test runner/setup is mismatched.