### PR TITLE
fix(feed): farmer social-feed sidebar matches the farmer workspace

### DIFF
--- a/frontend/assets/css/social-feed.css
+++ b/frontend/assets/css/social-feed.css
@@ -140,6 +140,26 @@ svg {
   color: #fff;
 }
 
+/* Section label matching the farmer workspace sidebar on the dashboard. */
+.feed-nav-heading {
+  margin: 0 0 6px;
+  padding: 5px 10px 8px;
+  color: #7b8a80;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+/* The farmer feed nav uses emoji icons (like the dashboard); reserve a uniform
+   slot so labels line up. The customer feed keeps its SVG icons untouched. */
+.feed-sidebar--farmer .feed-menu a span {
+  width: 22px;
+  flex: none;
+  text-align: center;
+  font-size: 15px;
+}
+
 .feed-main {
   min-width: 0;
   display: grid;

--- a/frontend/farmer-social-feed.html
+++ b/frontend/farmer-social-feed.html
@@ -11,45 +11,25 @@
 </head>
 <body>
   <div class="feed-app">
-    <aside class="feed-sidebar">
+    <aside class="feed-sidebar feed-sidebar--farmer">
       <a class="feed-brand" href="index.html" aria-label="FarmersHub farmer home">
         <img src="logo.png" alt="FarmersHub logo">
         <span>FarmersHub</span>
       </a>
 
       <nav class="feed-menu" aria-label="Farmer workspace navigation">
-        <a href="index.html">
-          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m3 11 9-8 9 8"/><path d="M5.5 10v10h13V10"/><path d="M10 20v-6h4v6"/></svg>
-          <span>Dashboard</span>
-        </a>
-        <a href="products-management.html">
-          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 7H4a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2Z"/><path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2"/></svg>
-          <span>Products</span>
-        </a>
-        <a href="orders.html">
-          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 7h16v13H4Z"/><path d="M8 7a4 4 0 0 1 8 0"/><path d="M9 11h6"/></svg>
-          <span>Orders</span>
-        </a>
-        <a href="messages.html">
-          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 5h16v12H8l-4 3V5Z"/></svg>
-          <span>Messages</span>
-        </a>
-        <a href="analytics.html">
-          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 3v18h18"/><path d="m7 16 4-4 4 4 5-5"/></svg>
-          <span>Analytics</span>
-        </a>
-        <a class="active" href="farmer-social-feed.html" aria-current="page">
-          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7 20c6 0 10-4 10-12V4C11 4 7 8 7 14v6Z"/><path d="M7 20c1-5 4-8 9-11"/></svg>
-          <span>Social Feed</span>
-        </a>
-        <a href="settings.html">
-          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 8.5a3.5 3.5 0 1 0 0 7 3.5 3.5 0 0 0 0-7Z"/><path d="M19 12a7 7 0 0 0-.1-1l2-1.5-2-3.4-2.4 1A7 7 0 0 0 15 6.2L14.7 4h-5.4L9 6.2a7 7 0 0 0-1.5.9l-2.4-1-2 3.4 2 1.5a7 7 0 0 0 0 2l-2 1.5 2 3.4 2.4-1a7 7 0 0 0 1.5.9l.3 2.2h5.4l.3-2.2a7 7 0 0 0 1.5-.9l2.4 1 2-3.4-2-1.5c.1-.3.1-.7.1-1Z"/></svg>
-          <span>Settings</span>
-        </a>
-        <a href="help-center.html">
-          <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M9.8 9a2.5 2.5 0 0 1 4.8 1c0 2-2.6 2-2.6 4"/><path d="M12 17.5v.1"/></svg>
-          <span>Help Center</span>
-        </a>
+        <p class="feed-nav-heading">Farmer Workspace</p>
+        <a href="index.html"><span>⌂</span> Dashboard</a>
+        <a href="products-management.html"><span>🌿</span> Products</a>
+        <a href="orders.html"><span>📦</span> Orders</a>
+        <a href="inventory.html"><span>🧺</span> Inventory</a>
+        <a href="messages.html"><span>✉</span> Messages</a>
+        <a href="customers.html"><span>👥</span> Customers</a>
+        <a href="analytics.html"><span>📈</span> Analytics</a>
+        <a class="active" href="farmer-social-feed.html" aria-current="page"><span>📣</span> Social Feed</a>
+        <a href="payments.html"><span>₩</span> Payments</a>
+        <a href="settings.html"><span>⚙</span> Settings</a>
+        <a href="help-center.html"><span>?</span> Help Center</a>
       </nav>
     </aside>
 


### PR DESCRIPTION
## Why
Follow-up to #79. The customer and farmer social feeds shared the same `feed-sidebar` styling, so the **farmer** feed looked like the customer home instead of the farmer dashboard. (This change landed just after #79 was squash-merged, so it wasn't included.)

## What
The feed *content* stays shared — only the farmer's **sidebar** now mirrors the farmer dashboard:
- "Farmer Workspace" heading
- Full farmer menu: Dashboard, Products, Orders, Inventory, Messages, Customers, Analytics, Social Feed, Payments, Settings, Help Center
- Emoji icons matching the dashboard
- Solid-green active item (verified `rgb(46,157,99)`, 42px, 13px) — identical to `fd-nav`

Scoped under a new `.feed-sidebar--farmer` modifier class, so the **customer feed is untouched**.

Net diff: 2 files (`farmer-social-feed.html`, `social-feed.css`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)