### PR TITLE
fix(wallet): balance not updating after admin recharge (one backend for all pages)

### DIFF
--- a/frontend/assets/js/config/api.config.js
+++ b/frontend/assets/js/config/api.config.js
@@ -22,7 +22,17 @@ function detectApiBase() {
     return PRODUCTION_API_BASE;
   }
 
-  // Match the login page: default to the deployed API unless explicitly overridden.
+  // When the app is served from a local backend (the dev setup serves the
+  // frontend from the same Express server), talk to that same-origin API.
+  // This keeps every page on one backend — previously only login/admin pages
+  // set this, so other pages silently hit the production API and showed stale
+  // data (e.g. a recharged wallet balance reading 0 from the wrong database).
+  const host = window.location.hostname;
+  if (host === 'localhost' || host === '127.0.0.1') {
+    return normalizeBase(`${window.location.origin}/api`);
+  }
+
+  // Default to the deployed API unless explicitly overridden.
   return PRODUCTION_API_BASE;
 }
 

--- a/frontend/assets/js/wallet-widget.js
+++ b/frontend/assets/js/wallet-widget.js
@@ -194,7 +194,12 @@ export async function initWalletWidget(options = {}) {
       balanceEl.textContent = won(data.balance);
       lastTransactions = data.transactions || [];
     } catch (err) {
-      balanceEl.textContent = '₩0';
+      // Surface the failure instead of masking it as a ₩0 balance — a silent
+      // zero hid issues like an expired session or wrong API target.
+      balanceEl.textContent = '—';
+      pendingEl.textContent = `Couldn't load balance: ${err.message || 'please sign in again'}`;
+      console.error('[wallet] failed to load balance:', err);
+      return;
     }
     try {
       const reqRes = await getMyRechargeRequests();


### PR DESCRIPTION
## Symptom
Admin approves a wallet recharge, but the customer's **My Balance** still shows **₩0**.

## Root cause
Only `login.html` and `admin.html` rewrite the API base to the local backend (`window.location.origin + '/api'`). Every other page — including `customer.html`, the farmer dashboard and the provider dashboard — falls back to the hardcoded **production** API in `api.config.js`.

So in local development the **admin credits the wallet in the local database**, while the **customer page reads the production database** → it never sees the new balance (₩0). The wallet widget also *silently* showed ₩0 on any fetch failure, which hid the problem.

## Fix
- **`api.config.js`** — on `localhost`/`127.0.0.1`, default the API base to the same-origin `/api`, so *every* page targets one backend (the same one login/admin already use). Production behaviour is unchanged.
- **`wallet-widget.js`** — show an explicit "Couldn't load balance…" message (and `console.error`) instead of a misleading ₩0 when the request fails.

## Test
1. Run the backend locally and open the app from the backend's origin (e.g. `http://localhost:5000`).
2. As a customer, request a recharge; as admin, approve it.
3. Reload the customer home → **My Balance** now reflects the credited amount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)