### PR TITLE
fix(wallet): one remote backend, fix 429 rate-limit, add farmer to provider service payments

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -28,6 +28,14 @@ const deliveryPartnerRoutes = require('./routes/deliveryPartners.routes');
 
 const app = express();
 
+// Render (and most PaaS hosts) put the app behind a reverse proxy, so the
+// client IP arrives in X-Forwarded-For. Trust the first proxy hop so
+// express-rate-limit keys on the real client IP instead of collapsing every
+// user into the proxy's single IP bucket (which made the whole app share one
+// rate-limit budget and return 429 for everyone). Use the number 1 rather than
+// `true` to avoid express-rate-limit's permissive-trust-proxy validation error.
+app.set('trust proxy', 1);
+
 // ── Security headers ───────────────────────────────────────────────────────────
 const isProduction = process.env.NODE_ENV === 'production';
 app.use(
@@ -72,9 +80,15 @@ app.use(
 // ── Global rate limiter ────────────────────────────────────────────────────────
 const limiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 200,
+  // A single dashboard load fans out into ~10-15 GETs (products, profile,
+  // notifications, wallet balance + recharge requests, feed, …), so 200 was
+  // exhausted after only a handful of page loads. 1000/15min leaves ample
+  // headroom for normal use while still capping abuse.
+  max: 1000,
   standardHeaders: true,
   legacyHeaders: false,
+  // CORS preflight requests shouldn't burn the budget.
+  skip: (req) => req.method === 'OPTIONS',
   message: { success: false, message: 'Too many requests — please try again later' },
 });
 app.use('/api', limiter);

--- a/backend/controllers/serviceRequestController.js
+++ b/backend/controllers/serviceRequestController.js
@@ -2,6 +2,7 @@ const { FarmServiceListing } = require('../models/FarmServiceListing');
 const { FarmServiceRequest } = require('../models/FarmServiceRequest');
 const { createNotification } = require('./notificationController');
 const { successResponse, errorResponse } = require('../utils/apiResponse');
+const walletService = require('../services/walletService');
 
 function userIdOf(user) {
   return String(user?._id || user?.id || '');
@@ -261,13 +262,33 @@ async function acceptServiceRequestQuote(req, res, next) {
       return errorResponse(res, 'Only quoted requests can be accepted', 400);
     }
 
+    const quotedAmount = asNumber(request.quote && request.quote.amount, 0);
+    if (quotedAmount <= 0) {
+      return errorResponse(res, 'This request has no valid quoted amount to accept', 400);
+    }
+
+    // Accepting the quote is the purchase: move the quoted amount from the
+    // farmer to the provider before marking the request accepted, mirroring how
+    // orders and delivery fees are charged on commit. If the transfer fails
+    // (e.g. insufficient funds) the request stays 'quoted' so it can be retried.
+    await walletService.transfer(req.user._id, request.provider.userId, quotedAmount, {
+      type: 'service_payment',
+      debitDescription: `Service — ${request.provider.businessName || 'provider'} (request ${request._id})`,
+      creditDescription: `Service — ${request.farmer.name || 'farmer'} (request ${request._id})`,
+      fromCounterparty: walletService.counterpartyFrom(req.user),
+      toCounterparty: { userId: request.provider.userId, name: request.provider.businessName || request.provider.name, role: 'provider' },
+      relatedId: request._id,
+      relatedModel: 'FarmServiceRequest',
+      insufficientMessage: 'Your wallet balance is too low to accept this quote. Recharge your wallet and try again.',
+    });
+
     request.status = 'accepted';
     await request.save();
     await request.populate('listing', 'title category listingType pricingType price');
     await notify(
       request.provider.userId,
       'Service quote accepted',
-      `${request.farmer.name} accepted your quote for ${request.listing.title}.`,
+      `${request.farmer.name} accepted and paid your quote for ${request.listing.title}.`,
       request._id
     );
 

--- a/backend/models/WalletTransaction.js
+++ b/backend/models/WalletTransaction.js
@@ -1,7 +1,7 @@
 const mongoose = require('mongoose');
 
 // Categories of money movement, used for labelling and filtering the ledger.
-const TX_TYPES = ['recharge', 'order_payment', 'order_refund', 'delivery_fee', 'adjustment'];
+const TX_TYPES = ['recharge', 'order_payment', 'order_refund', 'delivery_fee', 'service_payment', 'adjustment'];
 
 /**
  * Immutable ledger entry. A transfer between two accounts produces two entries
@@ -55,7 +55,7 @@ const walletTransactionSchema = new mongoose.Schema(
     },
     relatedModel: {
       type: String,
-      enum: ['Order', 'RechargeRequest', 'DeliveryPartner'],
+      enum: ['Order', 'RechargeRequest', 'DeliveryPartner', 'FarmServiceRequest'],
     },
   },
   { timestamps: true }

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -8,11 +8,6 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Sora:wght@600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/css/admin.css">
-  <script>
-    if (['localhost', '127.0.0.1'].includes(window.location.hostname)) {
-      window.FARMERSHUB_API_BASE = window.location.origin + '/api';
-    }
-  </script>
 </head>
 <body class="admin-body">
   <div class="admin-app">

--- a/frontend/assets/js/config/api.config.js
+++ b/frontend/assets/js/config/api.config.js
@@ -4,7 +4,6 @@
  */
 
 const PRODUCTION_API_BASE = 'https://farmershub-kkjd.onrender.com/api';
-const LOCAL_API_BASE = 'http://localhost:5000/api';
 const REQUEST_TIMEOUT_MS = 15000;
 
 function normalizeBase(url) {
@@ -17,22 +16,13 @@ function detectApiBase() {
   const runtimeOverride = normalizeBase(window.FARMERSHUB_API_BASE);
   if (runtimeOverride) return runtimeOverride;
 
-  // Support local development when opening static files directly (file://).
-  if (window.location.protocol === 'file:') {
-    return PRODUCTION_API_BASE;
-  }
-
-  // When the app is served from a local backend (the dev setup serves the
-  // frontend from the same Express server), talk to that same-origin API.
-  // This keeps every page on one backend — previously only login/admin pages
-  // set this, so other pages silently hit the production API and showed stale
-  // data (e.g. a recharged wallet balance reading 0 from the wrong database).
-  const host = window.location.hostname;
-  if (host === 'localhost' || host === '127.0.0.1') {
-    return normalizeBase(`${window.location.origin}/api`);
-  }
-
-  // Default to the deployed API unless explicitly overridden.
+  // The live backend is the deployed Render instance, not a local server.
+  // Every page must talk to that one remote backend so all pages share a
+  // single database — even in dev when the frontend is opened from localhost
+  // (the local Express server only serves static files). Previously localhost
+  // pages hit the local same-origin API, landing on a different database and
+  // showing stale data (e.g. a recharged wallet balance reading 0).
+  // Override with window.FARMERSHUB_API_BASE if you really do run a local API.
   return PRODUCTION_API_BASE;
 }
 

--- a/frontend/assets/js/customer-cart.js
+++ b/frontend/assets/js/customer-cart.js
@@ -208,6 +208,8 @@ async function checkout() {
   if (succeeded.length) {
     const succeededIds = new Set(succeeded.map((item) => item.id));
     saveCartItems(getCartItems().filter((item) => !succeededIds.has(item.id)));
+    // Each placed order debits the customer's wallet, so refresh the balance card.
+    window.dispatchEvent(new CustomEvent('fh-wallet-changed'));
   }
 
   if (!failed.length) {

--- a/frontend/assets/js/farmer-service-request.js
+++ b/frontend/assets/js/farmer-service-request.js
@@ -41,7 +41,9 @@ function renderSubmittedRequest(request) {
     accept.addEventListener('click', async () => {
       try {
         await acceptServiceRequestQuote(request.id);
-        setStatus('farmerServiceRequestStatus', 'Quote accepted.');
+        // Accepting pays the provider from the farmer's wallet — refresh balance.
+        window.dispatchEvent(new CustomEvent('fh-wallet-changed'));
+        setStatus('farmerServiceRequestStatus', 'Quote accepted and paid.');
         await loadExistingRequest(request.id);
       } catch (error) {
         setStatus('farmerServiceRequestStatus', error.message || 'Unable to accept quote.', 'error');

--- a/frontend/assets/js/farmer-service-requests.js
+++ b/frontend/assets/js/farmer-service-requests.js
@@ -36,8 +36,14 @@ async function reload() {
       accept.className = 'farmer-service-secondary-button';
       accept.textContent = 'Accept quote';
       accept.addEventListener('click', async () => {
-        await acceptServiceRequestQuote(request.id);
-        await reload();
+        try {
+          await acceptServiceRequestQuote(request.id);
+          // Accepting pays the provider from the farmer's wallet — refresh balance.
+          window.dispatchEvent(new CustomEvent('fh-wallet-changed'));
+          await reload();
+        } catch (error) {
+          setStatus('farmerServiceRequestsStatus', error.message || 'Unable to accept quote.', 'error');
+        }
       });
       actions.appendChild(accept);
     }

--- a/frontend/assets/js/wallet-widget.js
+++ b/frontend/assets/js/wallet-widget.js
@@ -23,6 +23,7 @@ function txLabel(tx) {
     order_payment: tx.direction === 'debit' ? 'Order payment' : 'Order received',
     order_refund: 'Order refund',
     delivery_fee: tx.direction === 'debit' ? 'Delivery fee paid' : 'Delivery earnings',
+    service_payment: tx.direction === 'debit' ? 'Service payment' : 'Service earnings',
     adjustment: 'Adjustment',
   };
   return tx.description || map[tx.type] || tx.type;

--- a/frontend/login/createAccount.js
+++ b/frontend/login/createAccount.js
@@ -6,15 +6,7 @@ function detectApiBase() {
   const runtimeOverride = normalizeBase(window.FARMERSHUB_API_BASE);
   if (runtimeOverride) return runtimeOverride;
 
-  if (window.location.protocol === 'file:') {
-    return 'https://farmershub-kkjd.onrender.com/api';
-  }
-
-  const host = window.location.hostname;
-  if (host === 'localhost' || host === '127.0.0.1') {
-    return 'http://localhost:5000/api';
-  }
-
+  // Always use the deployed backend so every page shares one database.
   return 'https://farmershub-kkjd.onrender.com/api';
 }
 

--- a/frontend/login/login.html
+++ b/frontend/login/login.html
@@ -142,11 +142,6 @@
   <div id="msg" class="message"></div>
 </div>
 
-<script>
-  if (['localhost', '127.0.0.1'].includes(window.location.hostname)) {
-    window.FARMERSHUB_API_BASE = window.location.origin + '/api';
-  }
-</script>
 <script src="./login.js"></script>
 <script>
 (function () {


### PR DESCRIPTION
## Overview
Follow-up to #81. Makes the virtual-wallet money flows consistent across one shared database, removes the 429 that blocked wallet reads, and wires the one money path that was still free (farmer paying a provider for a service).

## What changed & why

### 1. One remote backend (data consistency)
`api.config.js`, `admin.html`, `login.html`, and `createAccount.js` previously pointed at a localhost same-origin API when served locally. That split admin and customer pages across **two different databases**, which is why a recharged balance could read back as a stale `0`. All pages now always target the deployed Render API (runtime `window.FARMERSHUB_API_BASE` override still honored).

### 2. Fix the 429 ("Too many requests")
The app runs behind Render's reverse proxy with no `trust proxy` set, so `express-rate-limit` keyed every request to the proxy's single IP — **all users shared one 200-req/15-min budget**. Fixes:
- `app.set('trust proxy', 1)` so the limiter uses per-client buckets
- raised the global cap to 1000/15min (a single dashboard load fans out into ~10-15 GETs)
- skip CORS preflight `OPTIONS` requests

### 3. Farmer to provider service payments (new)
The service-request flow (request -> quote -> **accept** -> complete) moved no money. The farmer is now charged the quoted amount at **quote acceptance**, transferring it farmer -> provider — mirroring how orders and delivery fees charge on commit. Includes insufficient-funds handling (the request stays `quoted` so it can be retried).
- added `service_payment` tx type and `FarmServiceRequest` related-model to the wallet ledger
- ledger label + balance refresh (`fh-wallet-changed`) and error handling on both farmer "Accept quote" buttons

### 4. Balance refresh after checkout
Customer checkout debits the wallet but didn't refresh the balance card — now dispatches `fh-wallet-changed` on a successful order.

## Verification
- Backend module graph loads clean; no test suite exists in the repo.
- Manual end-to-end check, recommended on the deployed site since prod CORS rejects localhost origins:
  1. recharge -> admin approve -> customer balance updates, no 429 on repeated reloads
  2. customer checkout -> customer debited, farmer credited
  3. farmer assigns paid delivery -> farmer to provider; farmer accepts a service quote -> farmer to provider (and a too-low balance shows a clean error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
