### PR TITLE
fix(wallet): send auth token on wallet & delivery reads (balance now shows after recharge)

### DIFF
--- a/frontend/assets/js/services/deliveryPartnerService.js
+++ b/frontend/assets/js/services/deliveryPartnerService.js
@@ -1,8 +1,8 @@
-import { apiFetch, jsonHeaders } from '../config/api.config.js';
+import { apiFetch, jsonHeaders, authHeader } from '../config/api.config.js';
 
 // ── Provider: manage own delivery options ────────────────────────────────────
 async function getMyDeliveryPartners() {
-  return apiFetch('/delivery-partners/mine');
+  return apiFetch('/delivery-partners/mine', { headers: authHeader() });
 }
 
 async function createDeliveryPartner(payload) {
@@ -22,12 +22,12 @@ async function updateDeliveryPartner(id, payload) {
 }
 
 async function deleteDeliveryPartner(id) {
-  return apiFetch(`/delivery-partners/${id}`, { method: 'DELETE' });
+  return apiFetch(`/delivery-partners/${id}`, { method: 'DELETE', headers: authHeader() });
 }
 
 // ── Farmer: browse active options when shipping an order ──────────────────────
 async function getAvailableDeliveryPartners() {
-  return apiFetch('/delivery-partners/available');
+  return apiFetch('/delivery-partners/available', { headers: authHeader() });
 }
 
 export {

--- a/frontend/assets/js/services/walletService.js
+++ b/frontend/assets/js/services/walletService.js
@@ -1,8 +1,8 @@
-import { apiFetch, jsonHeaders } from '../config/api.config.js';
+import { apiFetch, jsonHeaders, authHeader } from '../config/api.config.js';
 
 // Wallet balance + recent ledger entries for the signed-in user.
 async function getWallet(limit = 20) {
-  return apiFetch(`/wallet?limit=${encodeURIComponent(limit)}`);
+  return apiFetch(`/wallet?limit=${encodeURIComponent(limit)}`, { headers: authHeader() });
 }
 
 // Ask the administrator to top up the wallet (amount in won, max 500,000).
@@ -16,13 +16,13 @@ async function createRechargeRequest(amount, note = '') {
 
 // The signed-in user's own recharge requests.
 async function getMyRechargeRequests() {
-  return apiFetch('/wallet/recharge-requests');
+  return apiFetch('/wallet/recharge-requests', { headers: authHeader() });
 }
 
 // ── Admin ────────────────────────────────────────────────────────────────────
 async function listRechargeRequests(status = '') {
   const qs = status ? `?status=${encodeURIComponent(status)}` : '';
-  return apiFetch(`/admin/recharge-requests${qs}`);
+  return apiFetch(`/admin/recharge-requests${qs}`, { headers: authHeader() });
 }
 
 async function reviewRechargeRequest(id, action, note = '') {


### PR DESCRIPTION
## The bug
After an admin approves a recharge, the credited balance never appeared on the customer's (or farmer's, or provider's) "My Balance" card — it showed `—` with *"Couldn't load balance: Not authorized — no token provided."*

## Root cause (found by testing against the live Render API + Atlas)
The frontend wallet/delivery **service GET and DELETE calls sent no `Authorization` header**, so the protected endpoints returned `401`. Reads failed; writes didn't — because POST/PATCH use `jsonHeaders()` (which includes the token). That's the exact asymmetry users hit: creating a recharge request and admin approval worked, but reading the balance always 401'd.

Verified on live:
- `register` / `login` → token issued ✅
- `GET /wallet` **with** a Bearer token → returns the balance ✅
- `GET /wallet` **without** a token → `401 no token provided` ❌ (what the deployed UI was doing)
- recharge request persists in the shared Atlas DB ✅

The DB connection, credit logic, and admin approval were all correct. The auth-header fix had existed on an old branch but was lost and **never reached `main`**, so the deployed `walletService.js` was still the unauthenticated version.

## The fix
Add `authHeader()` to every wallet/delivery read:
- `walletService.js`: `getWallet`, `getMyRechargeRequests`, `listRechargeRequests`
- `deliveryPartnerService.js`: `getMyDeliveryPartners`, `getAvailableDeliveryPartners`, `deleteDeliveryPartner`

(`serviceRequestService.js` already sends the token via `jsonHeaders()`, so the farmer→provider service flow was unaffected.)

## Verification after merge
On the deployed site, hard-refresh, log in, and the balance loads. End-to-end: recharge → admin approve → balance shows the credited amount; customer order debits/credits; farmer pays provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
